### PR TITLE
Fix JSON in .info, lowercase & standardize modId.

### DIFF
--- a/src/main/java/com/towerofbabel/towerofbabelmod/TowerOfBabel.java
+++ b/src/main/java/com/towerofbabel/towerofbabelmod/TowerOfBabel.java
@@ -35,7 +35,7 @@ import com.towerofbabel.towerofbabelmod.babel.ActionBlocker;
 public class TowerOfBabel
 {
 	public static final String NAME = "Tower of Babel";
-	public static final String MODID = "TowerOfBabel";
+	public static final String MODID = "towerofbabel";
 	public static final String VERSION = "1.0";
 
 	/**

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,7 +7,7 @@
   "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",
-  "authorList": ["LokiW", "deluxev2"],
+  "authorList": ["LokiW", "deluxev2", "RyanDBurnett"],
   "credits": "<3",
   "logoFile": "",
   "screenshots": [],

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,13 +1,13 @@
 [
 {
-  "modid": "towerofbabelmod",
+  "modid": "towerofbabel",
   "name": "Tower Of Babel Mod",
   "description": "Skill tree / progression mod.",
   "version": "${version}",
   "mcversion": "${mcversion}",
   "url": "",
   "updateUrl": "",
-  "authorList": ["LokiW". "deluxev2"],
+  "authorList": ["LokiW", "deluxev2"],
   "credits": "<3",
   "logoFile": "",
   "screenshots": [],


### PR DESCRIPTION
Forge appears to have errored for me while loading due to the Mod ID containing capital letters.  It also complained about the mcmod.info file not being in correct JSON formatting.  This PR addresses those issues.